### PR TITLE
Replace tab with whitespace

### DIFF
--- a/src/Spika/Db/DbInterface.php
+++ b/src/Spika/Db/DbInterface.php
@@ -3,7 +3,7 @@ namespace Spika\Db;
 
 interface DbInterface
 {
-	public function unregistToken($userId);
+    public function unregistToken($userId);
 
     public function checkEmailIsUnique($email);
 


### PR DESCRIPTION
細かいですが...

PHP では一般的にホワイトスペース 4 つでインデントしてます。
PSR-2 という規約でそうなってます。
http://www.infiniteloop.co.jp/docs/psr/psr-2-coding-style-guide.html
